### PR TITLE
feat(account): add new APIs for interaction with server's AddressBook

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,37 +40,8 @@ The `Dialer` requires the other peers to be already "registered" to connect with
 
 Example (register peer before propose a channel with them):
 ````go
-// OpenChannel opens a new channel with the specified peer and funding.
-func (c *PaymentClient) OpenChannel(peer wire.Address, peerID string, amount float64) *PaymentChannel {
-	....
-	```
-	c.net.Dialer.Register(peer, peerID)
-	```
-	... 
-
-	// Prepare the channel proposal by defining the channel parameters.
-	challengeDuration := uint64(10) // On-chain challenge duration in seconds.
-	proposal, err := client.NewLedgerChannelProposal(
-		challengeDuration,
-		c.account,
-		initAlloc,
-		participants,
-	)
-	if err != nil {
-		panic(err)
-	}
-
-	// Send the proposal.
-	ch, err := c.perunClient.ProposeChannel(context.TODO(), proposal)
-	if err != nil {
-		panic(err)
-	}
-
-	// Start the on-chain event watcher. It automatically handles disputes.
-	c.startWatching(ch)
-
-	return newPaymentChannel(ch, c.currency)
-}
+// Must be called at least once before attempting to connect with peer. 
+net.Dialer.Register(peer, peerID)
 ````
 
 ## Address Ressolver

--- a/README.md
+++ b/README.md
@@ -39,22 +39,14 @@ Example usage:
 The `Dialer` requires the other peers to be already "registered" to connect with them. Before dialing, the `Register` must be called. 
 
 Example (register peer before propose a channel with them):
-```go
+````go
 // OpenChannel opens a new channel with the specified peer and funding.
 func (c *PaymentClient) OpenChannel(peer wire.Address, peerID string, amount float64) *PaymentChannel {
-	// We define the channel participants. The proposer has always index 0. Here
-	// we use the on-chain addresses as off-chain addresses, but we could also
-	// use different ones.
-	participants := []wire.Address{c.waddress, peer}
-
+	....
+	```
 	c.net.Dialer.Register(peer, peerID)
-
-	// We create an initial allocation which defines the starting balances.
-	initAlloc := channel.NewAllocation(2, c.currency)
-	initAlloc.SetAssetBalances(c.currency, []channel.Bal{
-		EthToWei(big.NewFloat(amount)), // Our initial balance.
-		big.NewInt(0),                  // Peer's initial balance.
-	})
+	```
+	... 
 
 	// Prepare the channel proposal by defining the channel parameters.
 	challengeDuration := uint64(10) // On-chain challenge duration in seconds.
@@ -79,7 +71,26 @@ func (c *PaymentClient) OpenChannel(peer wire.Address, peerID string, amount flo
 
 	return newPaymentChannel(ch, c.currency)
 }
-```
+````
+
+## Address Ressolver
+A default address resolver was already built-in on the Perun-Relay-Server. You can use the provided APIs in order to `Register`, `Query`, `Deregister` your On-chain (L1) Address (Implementation of [Go-Perun] `wallet.Address`) to get the peer's `wire.Address` (`Peer.ID` of [Go-Libp2p])
+
+**Example:**
+````go
+// Should be used in the initialization of Perun-Client.
+err := acc.RegisterOnChainAddress(onChainAddr)
+
+
+// Query the peer's wire address, given its on-chain address.
+peerID, err := acc.QueryOnChainAddress(peerOnChainAddr)
+
+
+// Deregister the on-chain address, to be used before closing Perun-Client,
+err = acc.DeregisterOnChainAddress(onChainAddr)
+
+````
+
 ## Test
 Some unit tests are provided:
 ```

--- a/p2p/account_test.go
+++ b/p2p/account_test.go
@@ -2,8 +2,11 @@ package p2p
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
+	sim_wallet "perun.network/go-perun/backend/sim/wallet"
+	"perun.network/go-perun/wallet"
 	pkgtest "polycry.pt/poly-go/test"
 )
 
@@ -18,4 +21,191 @@ func getHost(t *testing.T) *Account {
 	acc := NewRandomAccount(rng)
 	assert.NotNil(t, acc)
 	return acc
+}
+
+func TestAddressBookRegister(t *testing.T) {
+	rng := pkgtest.Prng(t)
+	acc := NewRandomAccount(rng)
+	assert.NotNil(t, acc)
+
+	onChainAddr := sim_wallet.NewRandomAddress(rng)
+
+	err := acc.RegisterOnChainAddress(onChainAddr)
+	assert.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+}
+
+func TestAddressBookRegisterEmptyAddress(t *testing.T) {
+	rng := pkgtest.Prng(t)
+	acc := NewRandomAccount(rng)
+	assert.NotNil(t, acc)
+
+	emptyAddr := &sim_wallet.Address{}
+
+	assert.Panics(t, func() { acc.RegisterOnChainAddress(emptyAddr) })
+
+	var nilAddr wallet.Address
+	err := acc.RegisterOnChainAddress(nilAddr)
+	assert.Error(t, err)
+}
+
+func TestAddressBookDeregister(t *testing.T) {
+	rng := pkgtest.Prng(t)
+	acc := NewRandomAccount(rng)
+	assert.NotNil(t, acc)
+
+	onChainAddr := sim_wallet.NewRandomAddress(rng)
+
+	err := acc.RegisterOnChainAddress(onChainAddr)
+	assert.NoError(t, err)
+
+	err = acc.DeregisterOnChainAddress(onChainAddr)
+	assert.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+
+	// Trying to query it again will fail
+	_, err = acc.QueryOnChainAddress(onChainAddr)
+	assert.Error(t, err)
+}
+
+func TestAddressBookDeregisterPeer(t *testing.T) {
+	rng := pkgtest.Prng(t)
+	acc := NewRandomAccount(rng)
+	assert.NotNil(t, acc)
+
+	peer := NewRandomAccount(rng)
+	assert.NotNil(t, peer)
+	onChainAddr := sim_wallet.NewRandomAddress(rng)
+	peerOnChainAddr := sim_wallet.NewRandomAddress(rng)
+
+	err := acc.RegisterOnChainAddress(onChainAddr)
+	assert.NoError(t, err)
+
+	time.Sleep(1 * time.Millisecond)
+
+	err = peer.RegisterOnChainAddress(peerOnChainAddr)
+	assert.NoError(t, err)
+
+	err = acc.DeregisterOnChainAddress(onChainAddr)
+	assert.NoError(t, err)
+
+	// Trying to deregister the peer's address will not fail, but the server will not allow it.
+	err = acc.DeregisterOnChainAddress(peerOnChainAddr)
+	assert.NoError(t, err)
+
+	// Trying to query it again will be okay
+	peerID, err := acc.QueryOnChainAddress(peerOnChainAddr)
+	assert.NoError(t, err)
+
+	addr := peer.Address()
+	assert.Equal(t, peerID, addr)
+
+	err = peer.DeregisterOnChainAddress(peerOnChainAddr)
+	assert.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+}
+
+func TestAddressBookQuery_Fail(t *testing.T) {
+	rng := pkgtest.Prng(t)
+	acc := NewRandomAccount(rng)
+	assert.NotNil(t, acc)
+
+	onChainAddr := sim_wallet.NewRandomAddress(rng)
+
+	_, err := acc.QueryOnChainAddress(onChainAddr)
+	assert.Error(t, err)
+}
+
+func TestAddressBookQuery(t *testing.T) {
+	rng := pkgtest.Prng(t)
+	acc := NewRandomAccount(rng)
+	assert.NotNil(t, acc)
+
+	onChainAddr := sim_wallet.NewRandomAddress(rng)
+
+	err := acc.RegisterOnChainAddress(onChainAddr)
+	assert.NoError(t, err)
+
+	time.Sleep(10 * time.Millisecond)
+	peerID, err := acc.QueryOnChainAddress(onChainAddr)
+	assert.NoError(t, err)
+
+	addr := acc.Address()
+	assert.Equal(t, peerID, addr)
+
+	err = acc.DeregisterOnChainAddress(onChainAddr)
+	assert.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+}
+
+func TestAddressBookQueryPeer(t *testing.T) {
+	rng := pkgtest.Prng(t)
+	acc := NewRandomAccount(rng)
+	assert.NotNil(t, acc)
+
+	peer := NewRandomAccount(rng)
+	assert.NotNil(t, peer)
+	onChainAddr := sim_wallet.NewRandomAddress(rng)
+	peerOnChainAddr := sim_wallet.NewRandomAddress(rng)
+
+	err := acc.RegisterOnChainAddress(onChainAddr)
+	assert.NoError(t, err)
+
+	err = peer.RegisterOnChainAddress(peerOnChainAddr)
+	assert.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+	peerID, err := acc.QueryOnChainAddress(peerOnChainAddr)
+	assert.NoError(t, err)
+
+	addr := peer.Address()
+	assert.Equal(t, peerID, addr)
+
+	err = acc.DeregisterOnChainAddress(onChainAddr)
+	assert.NoError(t, err)
+
+	err = acc.DeregisterOnChainAddress(peerOnChainAddr)
+	assert.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+}
+
+func TestAddressBookRegisterQueryMultiple(t *testing.T) {
+	rng := pkgtest.Prng(t)
+	acc := NewRandomAccount(rng)
+	assert.NotNil(t, acc)
+
+	onChainAddr := sim_wallet.NewRandomAddress(rng)
+	onChainAddr2 := sim_wallet.NewRandomAddress(rng)
+
+	err := acc.RegisterOnChainAddress(onChainAddr)
+	assert.NoError(t, err)
+
+	err = acc.RegisterOnChainAddress(onChainAddr2)
+	assert.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
+
+	accID, err := acc.QueryOnChainAddress(onChainAddr)
+	assert.NoError(t, err)
+
+	accID2, err := acc.QueryOnChainAddress(onChainAddr2)
+	assert.NoError(t, err)
+
+	addr := acc.Address()
+	assert.Equal(t, accID, addr)
+	assert.Equal(t, accID2, addr)
+
+	// Clean up
+	err = acc.DeregisterOnChainAddress(onChainAddr)
+	assert.NoError(t, err)
+
+	err = acc.DeregisterOnChainAddress(onChainAddr2)
+	assert.NoError(t, err)
+
+	time.Sleep(1 * time.Second)
 }

--- a/p2p/account_test.go
+++ b/p2p/account_test.go
@@ -223,4 +223,5 @@ func TestNewAccountFromPrivateKey(t *testing.T) {
 	assert.NoError(t, err)
 	assert.NotNil(t, acc2)
 	assert.Equal(t, acc.ID(), acc2.ID())
+	assert.Equal(t, acc.Address(), acc2.Address())
 }

--- a/p2p/account_test.go
+++ b/p2p/account_test.go
@@ -209,3 +209,18 @@ func TestAddressBookRegisterQueryMultiple(t *testing.T) {
 
 	time.Sleep(1 * time.Second)
 }
+
+// Test NewAccountFromPrivateKey
+func TestNewAccountFromPrivateKey(t *testing.T) {
+	rng := pkgtest.Prng(t)
+	acc := NewRandomAccount(rng)
+	assert.NotNil(t, acc)
+
+	keyBytes, err := acc.MarshalPrivateKey()
+	assert.NoError(t, err)
+
+	acc2, err := NewAccountFromPrivateKeyBytes(keyBytes)
+	assert.NoError(t, err)
+	assert.NotNil(t, acc2)
+	assert.Equal(t, acc.ID(), acc2.ID())
+}


### PR DESCRIPTION
## Description
These changes come with the Integration of the Address Book on the Perun-Relay-Server. The Address Book is a database to register all peer's on-chain and off-chain addresses.


## Changes
**Location:** `account.go`, `account_test.go`

- Add new public Methods `QueryOnChainAddress`, `RegisterOnChainAddress`, `DeregisterOnChainAddress` in order to interact with the AddressBook on Relay-Server.

- Add test cases for the new methods.

- Update `README.md`