### PR TITLE
feat(temp): change crypto key pair to ed25519 

### DIFF
--- a/p2p/account.go
+++ b/p2p/account.go
@@ -109,7 +109,7 @@ func NewRandomAccount(rng *rand.Rand) *Account {
 	}
 
 	// Creates a new RSA key pair for this host.
-	prvKey, _, err := crypto.GenerateKeyPairWithReader(crypto.RSA, 2048, rng)
+	prvKey, _, err := crypto.GenerateKeyPairWithReader(crypto.Ed25519, 2048, rng)
 	if err != nil {
 		panic(err)
 	}

--- a/p2p/account_test.go
+++ b/p2p/account_test.go
@@ -230,11 +230,16 @@ func TestNewAccountFromPrivateKey(t *testing.T) {
 	acc := NewRandomAccount(rng)
 	assert.NotNil(t, acc)
 
+	defer acc.Close()
+
 	keyBytes, err := acc.MarshalPrivateKey()
 	assert.NoError(t, err)
 
 	acc2, err := NewAccountFromPrivateKeyBytes(keyBytes)
 	assert.NoError(t, err)
+
+	defer acc2.Close()
+
 	assert.NotNil(t, acc2)
 	assert.Equal(t, acc.ID(), acc2.ID())
 	assert.Equal(t, acc.Address(), acc2.Address())

--- a/p2p/address.go
+++ b/p2p/address.go
@@ -1,6 +1,7 @@
 package p2p
 
 import (
+	"crypto/sha256"
 	"fmt"
 	"math/rand"
 
@@ -66,7 +67,9 @@ func (a *Address) Verify(msg []byte, sig []byte) error {
 		return fmt.Errorf("extracting public key: %w", err)
 	}
 
-	b, err := publicKey.Verify(msg, sig)
+	hashed := sha256.Sum256(msg)
+
+	b, err := publicKey.Verify(hashed[:], sig)
 	if err != nil {
 		return fmt.Errorf("verifying signature: %w", err)
 	}

--- a/p2p/address_test.go
+++ b/p2p/address_test.go
@@ -5,8 +5,10 @@ import (
 	"testing"
 
 	"github.com/perun-network/perun-libp2p-wire/p2p"
+	"github.com/stretchr/testify/assert"
 	"perun.network/go-perun/wire"
 	"perun.network/go-perun/wire/test"
+	pkgtest "polycry.pt/poly-go/test"
 )
 
 func TestAddress(t *testing.T) {
@@ -15,4 +17,18 @@ func TestAddress(t *testing.T) {
 	}, func(rng *rand.Rand) wire.Address {
 		return p2p.NewRandomAddress(rng)
 	})
+}
+
+func TestSignature(t *testing.T) {
+	rng := pkgtest.Prng(t)
+	acc := p2p.NewRandomAccount(rng)
+	assert.NotNil(t, acc)
+	defer acc.Close()
+
+	msg := []byte("test message")
+	sig, err := acc.Sign(msg)
+	assert.NoError(t, err)
+
+	addr := acc.Address()
+	assert.NoError(t, addr.Verify(msg, sig))
 }


### PR DESCRIPTION
Change keypair generation to ed25519 because of libp2p bug #51 (https://github.com/libp2p/go-libp2p/blob/master/core/peer/peer_test.go)