### PR TITLE
feat: BREAKING: update to go-perun 0.13.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/multiformats/go-multiaddr v0.15.0
 	github.com/pkg/errors v0.9.1
 	github.com/stretchr/testify v1.10.0
-	perun.network/go-perun v0.12.0
+	perun.network/go-perun v0.13.0
 	polycry.pt/poly-go v0.0.0-20220222131629-aa4bdbaab60b
 )
 

--- a/go.sum
+++ b/go.sum
@@ -524,8 +524,8 @@ honnef.co/go/tools v0.0.0-20190102054323-c2f93a96b099/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190106161140-3f1c8253044a/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 lukechampine.com/blake3 v1.4.0 h1:xDbKOZCVbnZsfzM6mHSYcGRHZ3YrLDzqz8XnV4uaD5w=
 lukechampine.com/blake3 v1.4.0/go.mod h1:MQJNQCTnR+kwOP/JEZSxj3MaQjp80FOFSNMMHXcSeX0=
-perun.network/go-perun v0.12.0 h1:9Cdk5nHFYkegk+2FbqO9SjvgzUvduVWUiiJXrWkAwBA=
-perun.network/go-perun v0.12.0/go.mod h1:uH8iwi75alXDizxxDzH0A+6uqXPbagCpKfl8ECMv/cA=
+perun.network/go-perun v0.13.0 h1:MsL6r7Dgd5wJHb+IUChrTw+2D/7KDiP+6jpogbpP8/8=
+perun.network/go-perun v0.13.0/go.mod h1:uH8iwi75alXDizxxDzH0A+6uqXPbagCpKfl8ECMv/cA=
 polycry.pt/poly-go v0.0.0-20220222131629-aa4bdbaab60b h1:BJsSrLQ3kLRNYXNqly//IYeXlVmAhpI5wYbg2WD1wR0=
 polycry.pt/poly-go v0.0.0-20220222131629-aa4bdbaab60b/go.mod h1:XUBrNtqgEhN3EEOP/5gh7IBd3xVHKidCjXDZfl9+kMU=
 sourcegraph.com/sourcegraph/go-diff v0.5.0/go.mod h1:kuch7UrkMzY0X+p9CRK03kfuPQ2zzQcaEFbx8wA8rck=

--- a/p2p/account_test.go
+++ b/p2p/account_test.go
@@ -1,6 +1,8 @@
 package p2p
 
 import (
+	"log"
+	"math/rand"
 	"testing"
 	"time"
 
@@ -17,10 +19,9 @@ func TestNewAccount(t *testing.T) {
 	defer acc.Close()
 }
 
-func getHost(t *testing.T) *Account {
-	rng := pkgtest.Prng(t)
+func getHost(rng *rand.Rand) *Account {
 	acc := NewRandomAccount(rng)
-	assert.NotNil(t, acc)
+	log.Println(acc.Host.ID())
 	return acc
 }
 

--- a/p2p/bus.go
+++ b/p2p/bus.go
@@ -1,6 +1,8 @@
 package p2p
 
 import (
+	"perun.network/go-perun/wallet"
+	"perun.network/go-perun/wire"
 	"perun.network/go-perun/wire/net"
 	perunio "perun.network/go-perun/wire/perunio/serializer"
 )
@@ -15,9 +17,13 @@ type Net struct {
 
 // NewP2PBus creates a dialer, listener, and a bus for the given account `acc`
 // and includes them in the returned P2P Net.
-func NewP2PBus(acc *Account) (*Net, error) {
+func NewP2PBus(backendID wallet.BackendID, acc *Account) (*Net, error) {
 	listener := NewP2PListener(acc)
-	dialer := NewP2PDialer(acc, relayID, acc.relayAddr)
-	bus := net.NewBus(acc, dialer, perunio.Serializer())
-	return &Net{Bus: bus, Dialer: dialer, Listener: listener, PeerID: acc.ID().String()}, nil
+	dialer := NewP2PDialer(acc, relayID)
+
+	id := make(map[wallet.BackendID]wire.Account)
+	id[backendID] = acc
+
+	bus := net.NewBus(id, dialer, perunio.Serializer())
+	return &Net{Bus: bus, Dialer: dialer, Listener: listener, PeerID: acc.relayAddr}, nil
 }

--- a/p2p/listener_test.go
+++ b/p2p/listener_test.go
@@ -8,10 +8,12 @@ import (
 	perunio "perun.network/go-perun/wire/perunio/serializer"
 
 	ctxtest "polycry.pt/poly-go/context/test"
+	pkgtest "polycry.pt/poly-go/test"
 )
 
 func TestNewListener(t *testing.T) {
-	h := getHost(t)
+	rng := pkgtest.Prng(t)
+	h := getHost(rng)
 	l := NewP2PListener(h)
 	defer l.Close()
 	assert.NotNil(t, l)
@@ -19,7 +21,8 @@ func TestNewListener(t *testing.T) {
 
 func TestListener_Close(t *testing.T) {
 	t.Run("double close", func(t *testing.T) {
-		h := getHost(t)
+		rng := pkgtest.Prng(t)
+		h := getHost(rng)
 		l := NewP2PListener(h)
 		assert.NoError(t, l.Close(), "first close must not return error")
 		assert.Error(t, l.Close(), "second close must result in error")
@@ -28,8 +31,8 @@ func TestListener_Close(t *testing.T) {
 
 func TestListener_Accept(t *testing.T) {
 	// Happy case already tested in TestDialer_Dial.
-
-	h := getHost(t)
+	rng := pkgtest.Prng(t)
+	h := getHost(rng)
 	timeout := 100 * time.Millisecond
 	t.Run("timeout", func(t *testing.T) {
 		l := NewP2PListener(h)


### PR DESCRIPTION
This PR updates the perun-libp2p-wire to be used with go-perun v0.13.0, which introduce cross-chain features:

- wire.Address haven been refactored to become map[wallet.BackendID]wire.Address. 
- The current iteration uses only a single instant of libp2p Client to host all wire for all backends.
- NOTE: A case could be made so that each backend should have their own independent instance of Libp2p Client.